### PR TITLE
Fix/ios buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,15 @@
 
 A headless React carousel component that utilizes CSS scroll-snapping and JavaScript for progressive enhancement. Accessibility out of the box too!
 
-[View source code](https://github.com/mikeploythai/progressive-carousel/tree/main/src/components/carousel)
-
 > ⚠️ HEAVY WIP. USE AT YOUR OWN RISK
+
+[View source code](https://github.com/mikeploythai/progressive-carousel/tree/main/src/components/carousel)
 
 Documentation coming at some point!
 
 ## ⚠️ KNOWN ISSUES
 
-- Does not support carousels that uses `proximity` strictness
-- Carousel overshoots in iOS safari
+- Does not support carousels that uses `proximity` strictness (probably not planned to)
 
 ---
 

--- a/src/components/carousel/styles.module.css
+++ b/src/components/carousel/styles.module.css
@@ -23,7 +23,6 @@
 .carousel__slide {
   flex-shrink: 0;
   scroll-snap-align: start;
-  scroll-snap-stop: always;
   width: 100%;
 }
 


### PR DESCRIPTION
the prior implementation made the carousel scroll via the controls by scrolling the width of the carousel track itself, which only worked when tested on chromium because it respected the `scroll-snap-stop` css property set for the `.carousel-slide` class. on iOS, however, it did not respect that, which resulted in the carousel overshooting the next/previous slides when using the controls.

now, the hook tracks which slides are currently visible in the carousel track to accurately get the previous or next slide element via `previousElementSibling` and `nextElementSibling`. this allows us to calculate the proper amount of units to scroll to the target slide.

initially, i wanted to use the `scrollIntoView` method, which was almost perfect for the behavior i was looking for with far less code. the only issue was if i press the prev/next button in a carousel that's slightly out of view, it makes the page scroll up so the slide literally scrolls into view.